### PR TITLE
Directory structure fix

### DIFF
--- a/docs/dev-doc.md
+++ b/docs/dev-doc.md
@@ -17,6 +17,7 @@ All the project code is hosted in this GreenGrub directory so downloaded it is s
 We follow a standard directory layout for apps with a frontend and backend.
 This breakdown includes all the most important folders to know about.
 
+```
 GREENGRUB/
 ├── docs/              # User and developer documentation
 ├── .github/           # GitHub-specific configurations (e.g., workflows)
@@ -31,6 +32,7 @@ GREENGRUB/
      ├── assets/           # Static resources such as images, fonts, and icons
      ├── components/       # Reusable UI components used across screens
      └── constants/        # Centralized configuration (e.g., theme, colors, strings)
+```
 
 ## How to build the software
 


### PR DESCRIPTION
Fix directory structure in dev-doc.md by wrapping directory in correct syntax ```.

Before:
![image](https://github.com/user-attachments/assets/fd99f505-50d8-46d1-b1fe-cbd4a44d9e82)


After:
![image](https://github.com/user-attachments/assets/cb09e203-14e9-4842-a9ca-23674a758569)
